### PR TITLE
Support for Cycle Timing per instruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN On)
 
+option(CLOCK_SPEED_MHZ "The clock speed for the processor")
+
 add_subdirectory(emulator)
 add_subdirectory(emulator_app)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -129,7 +129,8 @@
             "inherits": ["unix-ninja", "deb", "conan-deb"],
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "-O0 --coverage -g -fsanitize=address",
-                "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/unix-deb-ninja/install"
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/unix-deb-ninja/install",
+                "CLOCK_SPEED_MHZ": "3.58"
             }
         },
         {

--- a/emulator/CMakeLists.txt
+++ b/emulator/CMakeLists.txt
@@ -8,4 +8,9 @@ target_sources(emulator
       emulator.cpp
 )
 
+if (CLOCK_SPEED_MHZ)
+  message(STATUS "The clock speed was set to ${CLOCK_SPEED_MHZ}")
+  target_compile_definitions(emulator PRIVATE CLOCK_SPEED_MHZ=${CLOCK_SPEED_MHZ})
+endif()
+
 target_link_libraries(emulator PRIVATE fmt::fmt)

--- a/emulator_app/main.cpp
+++ b/emulator_app/main.cpp
@@ -74,6 +74,8 @@ int main(int argc, char** argv)
 
     emulator::Cpu easy65k;
 
+    std::cout << std::format("The clock speed was set to {}\n", easy65k.clock_speed);
+
     auto const filename = argv[1];
     auto file           = std::ifstream{filename};
 

--- a/tests/increment_tests.cpp
+++ b/tests/increment_tests.cpp
@@ -8,6 +8,16 @@ import emulator;
 #include <utility>
 
 // NOLINTNEXTLINE
+TEST(IncrementTests, INXCorrectCycles)
+{
+    const std::array<std::uint8_t, 1> program{0xe8};
+
+    emulator::Cpu cpu;
+    auto const cycles = emulator::execute(cpu, {program.data(), program.size()});
+    ASSERT_EQ(cycles, 2);
+}
+
+// NOLINTNEXTLINE
 TEST(IncrementTests, INXNoFlags)
 {
     // TestData = (program, init_x_register)


### PR DESCRIPTION
* Changed the Instruction definition to account for cycles
* Changed the exported execute function to return overall cycles executed
* Added support for waiting for the right number of nanoseconds per instruction