### PR TITLE
AND absolute tests

### DIFF
--- a/emulator/emulator.cpp
+++ b/emulator/emulator.cpp
@@ -899,6 +899,8 @@ std::optional<std::size_t> or_acc_indirect_index(emulator::Cpu& cpu, std::span<c
 // from the start of the program
 std::array<Instruction, 256> get_instructions()
 {
+    // TODO : Goal is to have around all ~154 instructions supported
+
     // Byte key indicates which function we need to call
     // to handle the specific instruction
     // using Instruction = std::function<std::optional<std::size_t>(emulator::Cpu&, std::span<const std::uint8_t>)>;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ function(create_tests cpp_file_name)
   gtest_discover_tests(${cpp_file_name})
 endfunction()
 
+create_tests(and_absolute_tests)
 create_tests(and_immediate_tests)
 create_tests(branch_tests)
 create_tests(emulator_tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ function(create_tests cpp_file_name)
   gtest_discover_tests(${cpp_file_name})
 endfunction()
 
+create_tests(and_absolute_indexed_tests)
 create_tests(and_absolute_tests)
 create_tests(and_immediate_tests)
 create_tests(branch_tests)

--- a/tests/and_absolute_indexed_tests.cpp
+++ b/tests/and_absolute_indexed_tests.cpp
@@ -1,0 +1,100 @@
+/*
+This tests will check that the behaviour of the
+"AND" absolute opcodes, 0x3d & 0x39
+
+This instruction occupies three bytes: one for
+the opcode, and two fro the address (high bits,
+then low bits).
+
+This instruction takes:
+    - 4 cycles if the index is on the same page
+    - 5 cycles if the index crosses a page boundary
+*/
+
+import emulator;
+
+#include "common.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <utility>
+
+// NOLINTNEXTLINE
+TEST(ANDAbsoluteTests, PlusXTests)
+{
+    // test_case = {init acc, value, init_x, address, exp_mem, exp_flags}
+    std::array<std::tuple<std::uint8_t, std::uint8_t, std::uint8_t, std::uint16_t, std::uint16_t, emulator::Flags>,
+        4> const test_cases{{
+        {0b0101'0101, 0b0101'0101, 0x00, 0x0000, 0x0000, emulator::Flags{.n = false, .z = false}},
+        {0b0111'0101, 0b0101'0101, 0x01, 0x00ff, 0x0100, emulator::Flags{.n = false, .z = false}},
+        {0b1111'1111, 0b1111'1111, 0xff, 0xff00, 0xffff, emulator::Flags{.n = true, .z = false}},
+        {0b1010'1010, 0b0101'0101, 0x02, 0xffff, 0x0001, emulator::Flags{.n = false, .z = true}},
+    }};
+
+    for (auto const& [init_acc, value, init_x, address, exp_mem, exp_flags] : test_cases)
+    {
+        emulator::Cpu cpu;
+        cpu.reg.a        = init_acc;
+        cpu.reg.x        = init_x;
+        cpu.mem[exp_mem] = value;
+
+        auto const hsb = static_cast<std::uint8_t>((address >> 8) & 0b1111'11111);
+        auto const lsb = static_cast<std::uint8_t>(address & 0b1111'1111);
+        std::array<std::uint8_t, 3> const program{0x3d, lsb, hsb};
+
+        emulator::execute(cpu, program);
+
+        // Registry expect
+        ASSERT_EQ(cpu.reg.a, init_acc & value);
+        ASSERT_EQ(cpu.reg.x, init_x);
+        ASSERT_EQ(cpu.reg.y, 0x00);
+        ASSERT_EQ(cpu.reg.sp, 0x00);
+        ASSERT_EQ(cpu.reg.pc, 0x03);
+
+        // Flags expect
+        ASSERT_EQ(cpu.flags, exp_flags);
+    }
+}
+
+// NOLINTNEXTLINE
+TEST(ANDAbsoluteTests, PlusYTests)
+{
+    // test_case = {init acc, value, init_y, address, exp_mem}
+    std::array<std::tuple<std::uint8_t, std::uint8_t, std::uint8_t, std::uint16_t, std::uint16_t, emulator::Flags>,
+        4> const test_cases{{
+        {0b0101'0101, 0b0101'0101, 0x00, 0x0000, 0x0000, emulator::Flags{.n = false, .z = false}},
+        {0b0111'0101, 0b0101'0101, 0x01, 0x00ff, 0x0100, emulator::Flags{.n = false, .z = false}},
+        {0b1111'1111, 0b1111'1111, 0xff, 0xff00, 0xffff, emulator::Flags{.n = true, .z = false}},
+        {0b1010'1010, 0b0101'0101, 0x02, 0xffff, 0x0001, emulator::Flags{.n = false, .z = true}},
+    }};
+
+    for (auto const& [init_acc, value, init_y, address, exp_mem, exp_flags] : test_cases)
+    {
+        emulator::Cpu cpu;
+        cpu.reg.a        = init_acc;
+        cpu.reg.y        = init_y;
+        cpu.mem[exp_mem] = value;
+
+        auto const hsb = static_cast<std::uint8_t>((address >> 8) & 0b1111'1111);
+        auto const lsb = static_cast<std::uint8_t>(address & 0b1111'1111);
+        std::array<std::uint8_t, 3> const program{0x39, lsb, hsb};
+
+        emulator::execute(cpu, program);
+
+        // Registry expect
+        ASSERT_EQ(cpu.reg.a, init_acc & value);
+        ASSERT_EQ(cpu.reg.y, init_y);
+        ASSERT_EQ(cpu.reg.sp, 0x00);
+        ASSERT_EQ(cpu.reg.pc, 0x03);
+
+        // Flags expect
+        ASSERT_EQ(cpu.flags, exp_flags);
+    }
+}
+
+int main(int argc, char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/and_absolute_tests.cpp
+++ b/tests/and_absolute_tests.cpp
@@ -1,0 +1,59 @@
+/*
+This tests will check that the behaviour of the
+"AND" absolute opcode 0x2d
+
+This instruction occupies three bytes: one for
+the opcode, and two fro the address (high bits,
+then low bits).
+
+This instruction takes exactly four cycles.
+*/
+
+import emulator;
+
+#include "common.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <utility>
+
+// NOLINTNEXTLINE
+TEST(ANDAbsoluteTests, GeneralTests)
+{
+    // test_case = {init acc, value, target address, exp flags}
+    std::array<std::tuple<std::uint8_t, std::uint8_t, std::uint16_t, emulator::Flags>, 4> const test_cases{{
+        {0b0101'0101, 0b0101'0101, 0x0000, emulator::Flags{.n = false, .z = false}},
+        {0b0101'0101, 0b0101'0101, 0x00ff, emulator::Flags{.n = false, .z = false}},
+        {0b1111'1111, 0b1111'1111, 0xff00, emulator::Flags{.n = true, .z = false}},
+        {0b1010'1010, 0b0101'0101, 0xffff, emulator::Flags{.n = false, .z = true}},
+    }};
+
+    for (auto const& [init_acc, value, address, flags] : test_cases)
+    {
+        emulator::Cpu cpu;
+        cpu.reg.a        = init_acc;
+        cpu.mem[address] = value;
+
+        auto const hsb = static_cast<std::uint8_t>((address >> 8) & 0b1111'11111);
+        auto const lsb = static_cast<std::uint8_t>(address & 0b1111'1111);
+        std::array<std::uint8_t, 3> const program{0x2d, lsb, hsb};
+
+        emulator::execute(cpu, program);
+
+        // Registry expect
+        ASSERT_EQ(cpu.reg.a, init_acc & value);
+        ASSERT_EQ(cpu.reg.y, 0x00);
+        ASSERT_EQ(cpu.reg.sp, 0x00);
+        ASSERT_EQ(cpu.reg.pc, 0x03);
+
+        // Flags expect
+        ASSERT_EQ(cpu.flags, flags);
+    }
+}
+
+int main(int argc, char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/ora_absolute_indexed_tests.cpp
+++ b/tests/ora_absolute_indexed_tests.cpp
@@ -27,7 +27,7 @@ TEST(ORAAbsoluteTests, PlusXTests)
     std::array<std::tuple<std::uint8_t, std::uint8_t, std::uint8_t, std::uint16_t, std::uint16_t>, 4> const test_cases{{
         {0b0101'0101, 0b0010'1010, 0x00, 0x0000, 0x0000},
         {0b0101'0101, 0b0010'1010, 0x01, 0x00ff, 0x0100},
-        {0b0111'1111, 0b0000'0000, 0xff, 0xff00, 0x00ff},
+        {0b0111'1111, 0b0000'0000, 0xff, 0xff00, 0xffff},
         {0b0010'1010, 0b0101'0101, 0x02, 0xffff, 0x0001},
     }};
 
@@ -63,7 +63,7 @@ TEST(ORAAbsoluteTests, PlusYTests)
     std::array<std::tuple<std::uint8_t, std::uint8_t, std::uint8_t, std::uint16_t, std::uint16_t>, 4> const test_cases{{
         {0b0101'0101, 0b0010'1010, 0x00, 0x0000, 0x0000},
         {0b0101'0101, 0b0010'1010, 0x01, 0x00ff, 0x0100},
-        {0b0111'1111, 0b0000'0000, 0xff, 0xff00, 0x00ff},
+        {0b0111'1111, 0b0000'0000, 0xff, 0xff00, 0xffff},
         {0b0010'1010, 0b0101'0101, 0x02, 0xffff, 0x0001},
     }};
 


### PR DESCRIPTION
mainly ports from the ORA tests:

- Added the absolute + absolute_indexed tests
- Fixed bad memory expect in ORA tests, found only when the absolute tests were ported