### PR TITLE
Switching from Conan to CPM

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,3 +1,2 @@
 # Ignore all stuff in generated folders
 build/*
-conan/*

--- a/.clang-tidy-ignore
+++ b/.clang-tidy-ignore
@@ -1,4 +1,3 @@
 # Ignore all stuff in generated folders
 build/*
-conan/*
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .vscode
 build
-conan
 **/*.bin
 CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN On)
 
+add_subdirectory(dependencies)
+
 option(CLOCK_SPEED_MHZ "The clock speed for the processor")
 option(BUILD_PROFILER "Build profiling for the instruction handlers")
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,20 +2,6 @@
     "version": 2,
     "configurePresets": [
         {
-            "name": "conan-deb",
-            "hidden": true,
-            "cacheVariables": {
-                "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/conan/deb/conan_toolchain.cmake"
-            }
-        },
-        {
-            "name": "conan-rel",
-            "hidden": true,
-            "cacheVariables": {
-                "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/conan/rel/conan_toolchain.cmake"
-            }
-        },
-        {
             "name": "rel",
             "hidden": true,
             "cacheVariables": {
@@ -98,7 +84,7 @@
             "name": "unix-rel-ninja",
             "displayName": "Unix Ninja Clang Release",
             "binaryDir": "${sourceDir}/build/unix-rel-ninja",
-            "inherits": ["unix-ninja", "rel", "conan-rel"],
+            "inherits": ["unix-ninja", "rel"],
             "cacheVariables": {
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/unix-rel-ninja/install",
                 "BUILD_PROFILER": true
@@ -117,7 +103,7 @@
             "name": "unix-deb",
             "displayName": "Unix Make Debug",
             "binaryDir": "${sourceDir}/build/unix-deb",
-            "inherits": ["unix-make", "deb", "conan-deb"],
+            "inherits": ["unix-make", "deb"],
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "-O0 --coverage -g -fsanitize=address",
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/unix-deb/install"
@@ -127,7 +113,7 @@
             "name": "unix-deb-ninja",
             "displayName": "Unix Ninja Clang Debug",
             "binaryDir": "${sourceDir}/build/unix-deb-ninja",
-            "inherits": ["unix-ninja", "deb", "conan-deb"],
+            "inherits": ["unix-ninja", "deb"],
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "-O0 --coverage -g -fsanitize=address",
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/unix-deb-ninja/install",
@@ -157,7 +143,7 @@
             "name": "vs2022-deb",
             "displayName": "Visual Studio 2022 Debug",
             "binaryDir": "${sourceDir}/build/vs2022-deb",
-            "inherits": ["vs2022", "deb", "conan-deb"],
+            "inherits": ["vs2022", "deb"],
             "cacheVariables": {
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/vs2022-deb/install"
             }
@@ -175,7 +161,7 @@
             "name": "vs2022-deb-shared",
             "displayName": "Visual Studio 2022 Debug Shared",
             "binaryDir": "${sourceDir}/build/vs2022-deb-shared",
-            "inherits": ["vs2022-shared", "deb", "conan-deb"],
+            "inherits": ["vs2022-shared", "deb"],
             "cacheVariables": {
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/vs2022-rel/install"
             }

--- a/README.md
+++ b/README.md
@@ -12,12 +12,11 @@ This repository contains the source code for a 6502 Emulator, written in C++. Th
 To get started with the 65k-cpp emulator, clone the repository and follow the instructions below:
 
 The tools needed to build are:
-    - `conan2` for getting the third party libraries.
     - `cmake` version 3.28 or above.
+    - `ninja` version 1.11 or above.
 
 ```bash
 git clone https://github.com/matheusgomes28/65k-cpp.git
-conan install . --output-folder="conan/deb" -sbuild_type=Debug --build=missing
 cmake --preset unix-rel-ninja
 cmake --build --preset unit-rel-ninja
 ```

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,8 +1,0 @@
-[requires]
-fmt/11.0.2
-gtest/1.13.0
-raylib/5.0
-
-[generators]
-CMakeDeps
-CMakeToolchain

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -1,0 +1,38 @@
+
+file(
+  DOWNLOAD
+  https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.40.2/CPM.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake
+  EXPECTED_HASH SHA256=c8cdc32c03816538ce22781ed72964dc864b2a34a310d3b7104812a5ca2d835d
+)
+include(${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake)
+
+CPMAddPackage(
+  NAME raylib
+  GITHUB_REPOSITORY raysan5/raylib
+  GIT_TAG 5.0
+  VERSION 5.0
+)
+
+CPMAddPackage(
+  NAME googletest
+  GITHUB_REPOSITORY google/googletest
+  GIT_TAG v1.15.2
+  VERSION 1.15.2
+  OPTIONS
+    "INSTALL_GTEST OFF"
+    "gtest_force_shared_crt ON"
+    "BUILD_GMOCK OFF"
+)
+
+CPMAddPackage(
+  NAME fmt
+  GIT_TAG 11.0.2
+  VERSION 11.0.2
+  GITHUB_REPOSITORY fmtlib/fmt
+)
+
+# Aliases
+add_library(gtest::gtest ALIAS gtest)
+add_library(gtest::gtest_main ALIAS gtest_main)
+add_library(raylib::raylib ALIAS raylib)

--- a/emulator/CMakeLists.txt
+++ b/emulator/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(fmt REQUIRED)
-
 add_library(emulator)
 target_sources(emulator
   PUBLIC

--- a/emulator_app/CMakeLists.txt
+++ b/emulator_app/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-find_package(raylib REQUIRED)
-
 add_executable(emulator_app main.cpp)
 target_link_libraries(emulator_app
  PRIVATE

--- a/scripts/gather_cov.sh
+++ b/scripts/gather_cov.sh
@@ -19,12 +19,12 @@ lcov --capture --directory . --output-file lcov.info \
 
 
 SYSTEM_DIR="/usr/"
-CONAN_DIR="${HOME}/.conan2/"
+CPM_DIR="${HOME}/.cpm/"
 
 # Remove the system & test dirs
 lcov --ignore-errors inconsistent --remove lcov.info "${SYSTEM_DIR}*" --output-file lcov.info
-lcov --ignore-errors inconsistent --remove lcov.info "${CONAN_DIR}*" --output-file lcov.info
 lcov --ignore-errors inconsistent --remove lcov.info "${PROJECT_DIR}/tests*" --output-file lcov.info
+lcov --ignore-errors inconsistent --remove lcov.info "${CPM_DIR}*" --output-file lcov.info
 
 # Generate HTML report into coverage/
 genhtml lcov.info --ignore-errors inconsistent --ignore-errors corrupt --output-directory coverage > coverage_stats.txt

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,6 @@
 include(CTest)
 include(GoogleTest)
 
-find_package(GTest REQUIRED COMPONENTS gtest_main)
-
-
 # This is meant to be used on single .cpp files that
 # export GTest functions. Use "create_tests" by calling
 # it with the filename minus the extension.

--- a/tests/ld_index_indirect_tests.cpp
+++ b/tests/ld_index_indirect_tests.cpp
@@ -127,3 +127,9 @@ TEST(LDTests, LDAIndexIndirectXNonZeroPosWrap)
     // Flags expect
     ASSERT_EQ(cpu.flags, make_flags(0b0000'0000));
 }
+
+int main(int argc, char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
CPM is essentially a wrapper around CMake's `FetchContent_*` which allows for local download caching, and better dependency management.

In this PR, we switch from Conan to CPM so we no longer require Python for building this project.