### PR TITLE
Simplified unit tests without boiler plate:

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,8 @@ function(create_tests cpp_file_name)
   target_link_libraries(${cpp_file_name}
   PRIVATE
     emulator
-    gtest::gtest)
+    gtest::gtest
+    gtest::gtest_main)
 
   add_test(NAME ${cpp_file_name} COMMAND ${cpp_file_name})
   gtest_discover_tests(${cpp_file_name})

--- a/tests/and_absolute_indexed_tests.cpp
+++ b/tests/and_absolute_indexed_tests.cpp
@@ -92,9 +92,3 @@ TEST(ANDAbsoluteTests, PlusYTests)
         ASSERT_EQ(cpu.flags, exp_flags);
     }
 }
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/and_absolute_tests.cpp
+++ b/tests/and_absolute_tests.cpp
@@ -51,9 +51,3 @@ TEST(ANDAbsoluteTests, GeneralTests)
         ASSERT_EQ(cpu.flags, flags);
     }
 }
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/and_immediate_tests.cpp
+++ b/tests/and_immediate_tests.cpp
@@ -104,7 +104,7 @@ TEST(ANDImmediateTests, ZeroFlagOperation)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -154,10 +154,4 @@ TEST(ANDImmediateTests, MakeSureFlagsAreSound)
             }
         }
     }
-}
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/and_indexed_indirect_tests.cpp
+++ b/tests/and_indexed_indirect_tests.cpp
@@ -41,7 +41,7 @@ TEST(ANDIndexedIndirectTests, ZeroAddressToLastAddress)
     ASSERT_EQ(cpu.reg.a, 0b0111'1111);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -71,16 +71,9 @@ TEST(ANDIndexedIndirectTests, ZeropageWrapsAround)
     ASSERT_EQ(cpu.reg.a, 0b0111'1111);
     ASSERT_EQ(cpu.reg.x, 0x01);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
     ASSERT_EQ(cpu.flags, make_flags(0b0000'0000));
-}
-
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/and_indirect_indexed_tests.cpp
+++ b/tests/and_indirect_indexed_tests.cpp
@@ -41,7 +41,7 @@ TEST(ANDIndirectIndexedTests, ZeroAddressToLastAddress)
     ASSERT_EQ(cpu.reg.a, 0b0111'1111);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x01);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -73,15 +73,9 @@ TEST(ANDIndirectIndexedTests, ZeropageWrapsAround)
     ASSERT_EQ(cpu.reg.a, 0b0111'1111);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x01);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
     ASSERT_EQ(cpu.flags, make_flags(0b0000'0000));
-}
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/and_zeropage_indexed_tests.cpp
+++ b/tests/and_zeropage_indexed_tests.cpp
@@ -57,9 +57,3 @@ TEST(ANDZeropageIndexTests, WrapAroundTests)
         ASSERT_EQ(cpu.flags, make_flags(0b0000'0000));
     }
 }
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/and_zeropage_tests.cpp
+++ b/tests/and_zeropage_tests.cpp
@@ -126,9 +126,3 @@ TEST(ANDZeropageTests, ZeroFlagOperation)
         ASSERT_EQ(cpu.flags, make_flags(0b0000'0010));
     }
 }
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/branch_tests.cpp
+++ b/tests/branch_tests.cpp
@@ -529,9 +529,3 @@ TEST(BranchingTests, BranchOnOverflowClearWhenUnset)
         ASSERT_EQ(cpu.flags, make_flags(0b0000'0000));
     }
 }
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/emulator_tests.cpp
+++ b/tests/emulator_tests.cpp
@@ -164,9 +164,3 @@ TEST(EmulatorTests, EmulateCpxSetCarry)
         ASSERT_EQ(cpu.flags.c, 0);
     }
 }
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/eor_absolute_indexed_tests.cpp
+++ b/tests/eor_absolute_indexed_tests.cpp
@@ -92,9 +92,3 @@ TEST(EORbsoluteTests, PlusYTests)
         ASSERT_EQ(cpu.flags, exp_flags);
     }
 }
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/eor_absolute_tests.cpp
+++ b/tests/eor_absolute_tests.cpp
@@ -51,9 +51,3 @@ TEST(EORAbsoluteTests, GeneralTests)
         ASSERT_EQ(cpu.flags, flags);
     }
 }
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/eor_immediate_tests.cpp
+++ b/tests/eor_immediate_tests.cpp
@@ -170,9 +170,3 @@ TEST(EORImmediateTests, MakeSureFlagsAreSound)
         }
     }
 }
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/eor_indexed_indirect_tests.cpp
+++ b/tests/eor_indexed_indirect_tests.cpp
@@ -41,7 +41,7 @@ TEST(EORIndexedIndirectTests, ZeroAddressToLastAddress)
     ASSERT_EQ(cpu.reg.a, 0b0111'1111);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -71,16 +71,9 @@ TEST(EORIndexedIndirectTests, ZeropageWrapsAround)
     ASSERT_EQ(cpu.reg.a, 0b0111'1111);
     ASSERT_EQ(cpu.reg.x, 0x01);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
     ASSERT_EQ(cpu.flags, make_flags(0b0000'0000));
-}
-
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/eor_indirect_indexed_tests.cpp
+++ b/tests/eor_indirect_indexed_tests.cpp
@@ -41,7 +41,7 @@ TEST(EORIndirectIndexedTests, ZeroAddressToLastAddress)
     ASSERT_EQ(cpu.reg.a, 0b0111'1111);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x01);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -73,15 +73,9 @@ TEST(EORIndirectIndexedTests, ZeropageWrapsAround)
     ASSERT_EQ(cpu.reg.a, 0b0111'1111);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x01);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
     ASSERT_EQ(cpu.flags, make_flags(0b0000'0000));
-}
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/eor_zeropage_indexed_tests.cpp
+++ b/tests/eor_zeropage_indexed_tests.cpp
@@ -52,9 +52,3 @@ TEST(EORZeropageIndexTests, WrapAroundTests)
         ASSERT_EQ(cpu.flags, make_flags(0b0000'0000));
     }
 }
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/eor_zeropage_tests.cpp
+++ b/tests/eor_zeropage_tests.cpp
@@ -132,9 +132,3 @@ TEST(EORZeropageTests, ZeroFlagOperation)
         ASSERT_EQ(cpu.flags, make_flags(0b0000'0010));
     }
 }
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/flags_tests.cpp
+++ b/tests/flags_tests.cpp
@@ -94,9 +94,3 @@ TEST(FlagsTests, SRGetsBreak)
     cpu.flags.b = true;
     ASSERT_EQ(cpu.sr(), 0b0001'0000);
 }
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/increment_tests.cpp
+++ b/tests/increment_tests.cpp
@@ -217,7 +217,7 @@ TEST(IncrementTests, INXZeroFlag)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x01);
 
     ASSERT_EQ(cpu.flags, make_flags(0b0000'0010));
@@ -235,7 +235,7 @@ TEST(IncrementTests, INYZeroFlag)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x01);
 
     ASSERT_EQ(cpu.flags, make_flags(0b0000'0010));
@@ -253,7 +253,7 @@ TEST(IncrementTests, INCZeropageZeroFlag)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     ASSERT_EQ(cpu.mem[0x0a], 0x00);
@@ -273,7 +273,7 @@ TEST(IncrementTests, INCZeropagePluxXZeroFlag)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x0a);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     ASSERT_EQ(cpu.mem[0x0a], 0x00);
@@ -297,7 +297,7 @@ TEST(IncrementTests, INCAbsoluteZeroFlag)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     ASSERT_EQ(cpu.mem[pos], 0x00);
@@ -322,7 +322,7 @@ TEST(IncrementTests, INCAbsolutePluxXZeroFlag)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x0a);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     ASSERT_EQ(cpu.mem[0x0a], 0x00);
@@ -547,10 +547,4 @@ TEST(IncrementTests, INCAbsolutePluxXNegativeFlag)
         ASSERT_EQ(cpu.mem[pos], init_v + 1);
         ASSERT_EQ(cpu.flags, make_flags(0b1000'0000));
     }
-}
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/ld_absolute_indexed_tests.cpp
+++ b/tests/ld_absolute_indexed_tests.cpp
@@ -46,7 +46,7 @@ TEST(LDTests, LDAAbsolutePlusXNonZero)
     ASSERT_EQ(cpu.reg.a, 0x5a);
     ASSERT_EQ(cpu.reg.x, 0x13);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -76,7 +76,7 @@ TEST(LDTests, LDAAbsolutePlusYNonZero)
     ASSERT_EQ(cpu.reg.a, 0x5a);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x13);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -106,7 +106,7 @@ TEST(LDTests, LDXAbsolutePlusYNonZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x5a);
     ASSERT_EQ(cpu.reg.y, 0x13);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -136,7 +136,7 @@ TEST(LDTests, LDYAbsolutePlusXNonZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x13);
     ASSERT_EQ(cpu.reg.y, 0x5a);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -167,7 +167,7 @@ TEST(LDTests, LDAAbsolutePlusXWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x13);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -198,7 +198,7 @@ TEST(LDTests, LDAAbsolutePlusYWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x13);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -229,7 +229,7 @@ TEST(LDTests, LDXAbsolutePlusYWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x13);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -260,7 +260,7 @@ TEST(LDTests, LDYAbsolutePlusXWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x13);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -287,7 +287,7 @@ TEST(LDTests, LDAAbsolutePlusXWithNegative)
     ASSERT_EQ(cpu.reg.a, 0xFF);
     ASSERT_EQ(cpu.reg.x, 0x13);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -314,7 +314,7 @@ TEST(LDTests, LDAAbsolutePlusYWithNegative)
     ASSERT_EQ(cpu.reg.a, 0xFF);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x13);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -341,7 +341,7 @@ TEST(LDTests, LDXAbsolutePlusYWithNegative)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0xFF);
     ASSERT_EQ(cpu.reg.y, 0x13);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -368,15 +368,9 @@ TEST(LDTests, LDYAbsolutePlusXWithNegative)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x13);
     ASSERT_EQ(cpu.reg.y, 0xFF);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
     ASSERT_EQ(cpu.flags, make_flags(0b1000'0000));
-}
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/ld_absolute_tests.cpp
+++ b/tests/ld_absolute_tests.cpp
@@ -42,7 +42,7 @@ TEST(LDTests, LDAAbsoluteNonZero)
     ASSERT_EQ(cpu.reg.a, 0x5a);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -67,7 +67,7 @@ TEST(LDTests, LDXAbsoluteNonZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x5a);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -92,7 +92,7 @@ TEST(LDTests, LDYAbsoluteNonZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x5a);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -117,7 +117,7 @@ TEST(LDTests, LDAAbsoluteWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -142,7 +142,7 @@ TEST(LDTests, LDXAbsoluteWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -167,7 +167,7 @@ TEST(LDTests, LDYAbsoluteWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -192,7 +192,7 @@ TEST(LDTests, LDAAbsoluteWithNegative)
     ASSERT_EQ(cpu.reg.a, 0xFF);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -217,7 +217,7 @@ TEST(LDTests, LDXAbsoluteWithNegative)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0xFF);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
@@ -242,15 +242,9 @@ TEST(LDTests, LDYAbsoluteWithNegative)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0xFF);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x03);
 
     // Flags expect
     ASSERT_EQ(cpu.flags, make_flags(0b1000'0000));
-}
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/ld_immediate_tests.cpp
+++ b/tests/ld_immediate_tests.cpp
@@ -35,7 +35,7 @@ TEST(LDTests, LdAImmediateWithNonZero)
     ASSERT_EQ(cpu.reg.a, 0x0a);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -59,7 +59,7 @@ TEST(LDTests, LdAImmediateWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect - Zero flag should be true
@@ -83,7 +83,7 @@ TEST(LDTests, LdAImmediateWithNegative)
     ASSERT_EQ(cpu.reg.a, 0xFF);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect - n (negative) should be set
@@ -104,7 +104,7 @@ TEST(LDTests, LdXImmediateWithNonZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x0a);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -124,7 +124,7 @@ TEST(LDTests, LdXImmediateWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect - Zero flag should be true
@@ -144,7 +144,7 @@ TEST(LDTests, LdXImmediateWithNegative)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0xFF);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect - n (negative) should be set
@@ -166,7 +166,7 @@ TEST(LDTests, LdYImmediateWithNonZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x0a);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -186,7 +186,7 @@ TEST(LDTests, LdYImmediateWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect - Zero flag should be true
@@ -206,15 +206,9 @@ TEST(LDTests, LdYImmediateWithNegative)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0xFF);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect - n (negative) should be set
     ASSERT_EQ(cpu.flags, make_flags(0b1000'0000));
-}
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/ld_index_indirect_tests.cpp
+++ b/tests/ld_index_indirect_tests.cpp
@@ -36,7 +36,7 @@ TEST(LDTests, LDAIndexIndirectXNonZero)
     ASSERT_EQ(cpu.reg.a, 0x5a);
     ASSERT_EQ(cpu.reg.x, 0x13);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -64,7 +64,7 @@ TEST(LDTests, LDAIndexIndirectXWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x13);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -91,7 +91,7 @@ TEST(LDTests, LDAIndexIndirectXNegative)
     ASSERT_EQ(cpu.reg.a, 0xff);
     ASSERT_EQ(cpu.reg.x, 0x13);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -121,15 +121,9 @@ TEST(LDTests, LDAIndexIndirectXNonZeroPosWrap)
     ASSERT_EQ(cpu.reg.a, 0x5a);
     ASSERT_EQ(cpu.reg.x, 0x12);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
     ASSERT_EQ(cpu.flags, make_flags(0b0000'0000));
-}
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/ld_indirect_indexed_tests.cpp
+++ b/tests/ld_indirect_indexed_tests.cpp
@@ -38,7 +38,7 @@ TEST(LDTests, LDAIndirectIndexYNonZero)
     ASSERT_EQ(cpu.reg.a, 0x5a);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x01);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -67,7 +67,7 @@ TEST(LDTests, LDAIndirectIndexYWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x01);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -95,15 +95,9 @@ TEST(LDTests, LDAIndirectIndexYWithNegative)
     ASSERT_EQ(cpu.reg.a, 0xff);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x01);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
     ASSERT_EQ(cpu.flags, make_flags(0b1000'0000));
-}
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/ld_zeropage_indexed_tests.cpp
+++ b/tests/ld_zeropage_indexed_tests.cpp
@@ -34,7 +34,7 @@ TEST(LDTests, LDAZeropagePlusXWithNonZero)
     ASSERT_EQ(cpu.reg.a, 0x5a);
     ASSERT_EQ(cpu.reg.x, 0x10);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -59,7 +59,7 @@ TEST(LDTests, LDAZeropagePlusXWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x10);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -84,7 +84,7 @@ TEST(LDTests, LDAZeropagePlusXWithNegative)
     ASSERT_EQ(cpu.reg.a, 0xFF);
     ASSERT_EQ(cpu.reg.x, 0x10);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -109,7 +109,7 @@ TEST(LDTests, LDXZeropagePlusYWithNonZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x5a);
     ASSERT_EQ(cpu.reg.y, 0x10);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -134,7 +134,7 @@ TEST(LDTests, LDXZeropagePlusYWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x10);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -159,7 +159,7 @@ TEST(LDTests, LDXZeropagePlusYWithNegative)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0xFF);
     ASSERT_EQ(cpu.reg.y, 0x10);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -184,7 +184,7 @@ TEST(LDTests, LDYZeropagePlusXWithNonZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x10);
     ASSERT_EQ(cpu.reg.y, 0x5a);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -209,7 +209,7 @@ TEST(LDTests, LDYZeropagePlusXWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x10);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -234,15 +234,9 @@ TEST(LDTests, LDYZeropagePlusXWithNegative)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x10);
     ASSERT_EQ(cpu.reg.y, 0xFF);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
     ASSERT_EQ(cpu.flags, make_flags(0b1000'0000));
-}
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/ld_zeropage_tests.cpp
+++ b/tests/ld_zeropage_tests.cpp
@@ -37,7 +37,7 @@ TEST(LDTests, LDAZeropageWithNonZero)
     ASSERT_EQ(cpu.reg.a, 0x5a);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -62,7 +62,7 @@ TEST(LDTests, LDAZeropageWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect - Zero flag should be true
@@ -88,7 +88,7 @@ TEST(LDTests, LDAZeropageWithNegative)
     ASSERT_EQ(cpu.reg.a, 0xff);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect - n (negative) should be set
@@ -114,7 +114,7 @@ TEST(LDTests, LDXZeropageWithNonZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x5a);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -139,7 +139,7 @@ TEST(LDTests, LDXZeropageWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect - Zero flag should be true
@@ -165,7 +165,7 @@ TEST(LDTests, LDXZeropageWithNegative)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0xff);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect - n (negative) should be set
@@ -191,7 +191,7 @@ TEST(LDTests, LDYZeropageWithNonZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x5a);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -216,7 +216,7 @@ TEST(LDTests, LDYZeropageWithZero)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect - Zero flag should be true
@@ -242,15 +242,9 @@ TEST(LDTests, LDYZeropageWithNegative)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0xff);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect - n (negative) should be set
     ASSERT_EQ(cpu.flags, make_flags(0b1000'0000));
-}
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/ora_absolute_indexed_tests.cpp
+++ b/tests/ora_absolute_indexed_tests.cpp
@@ -90,9 +90,3 @@ TEST(ORAAbsoluteTests, PlusYTests)
         ASSERT_EQ(cpu.flags, make_flags(0b0000'0000));
     }
 }
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/ora_absolute_tests.cpp
+++ b/tests/ora_absolute_tests.cpp
@@ -51,9 +51,3 @@ TEST(ORAAbsoluteTests, GeneralTests)
         ASSERT_EQ(cpu.flags, make_flags(0b0000'0000));
     }
 }
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/ora_immediate_tests.cpp
+++ b/tests/ora_immediate_tests.cpp
@@ -107,7 +107,7 @@ TEST(ORAImmediateTests, ZeroFlagOperation)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -157,10 +157,4 @@ TEST(ORAImmediateTests, MakeSureFlagsAreSound)
             }
         }
     }
-}
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/ora_indexed_indirect_tests.cpp
+++ b/tests/ora_indexed_indirect_tests.cpp
@@ -41,7 +41,7 @@ TEST(ORAIndexedIndirectTests, ZeroAddressToLastAddress)
     ASSERT_EQ(cpu.reg.a, 0b0111'1111);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -71,16 +71,9 @@ TEST(ORAIndexedIndirectTests, ZeropageWrapsAround)
     ASSERT_EQ(cpu.reg.a, 0b0111'1111);
     ASSERT_EQ(cpu.reg.x, 0x01);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
     ASSERT_EQ(cpu.flags, make_flags(0b0000'0000));
-}
-
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/ora_indirect_indexed_tests.cpp
+++ b/tests/ora_indirect_indexed_tests.cpp
@@ -41,7 +41,7 @@ TEST(ORAIndirectIndexedTests, ZeroAddressToLastAddress)
     ASSERT_EQ(cpu.reg.a, 0b0111'1111);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x01);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -73,16 +73,9 @@ TEST(ORAIndirectIndexedTests, ZeropageWrapsAround)
     ASSERT_EQ(cpu.reg.a, 0b0111'1111);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x01);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
     ASSERT_EQ(cpu.flags, make_flags(0b0000'0000));
-}
-
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/ora_zeropage_index_tests.cpp
+++ b/tests/ora_zeropage_index_tests.cpp
@@ -57,9 +57,3 @@ TEST(ORAZeropageIndexTests, WrapAroundTests)
         ASSERT_EQ(cpu.flags, make_flags(0b0000'0000));
     }
 }
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/ora_zeropage_tests.cpp
+++ b/tests/ora_zeropage_tests.cpp
@@ -111,7 +111,7 @@ TEST(ORAZeropageTests, ZeroFlagOperation)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x02);
 
     // Flags expect
@@ -162,10 +162,4 @@ TEST(ORAZeropageTests, MakeSureFlagsAreSound)
             }
         }
     }
-}
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/tests/pha_tests.cpp
+++ b/tests/pha_tests.cpp
@@ -54,9 +54,3 @@ TEST(PHATests, PushedOverflow)
     ASSERT_EQ(cpu.mem[0x0100], 0x42);
     ASSERT_EQ(cpu.mem[0x01ff], 0x42);
 }
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/tx_tests.cpp
+++ b/tests/tx_tests.cpp
@@ -202,7 +202,7 @@ TEST(TXTests, TXAZeroFlag)
 
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x01);
 
     ASSERT_EQ(cpu.flags, make_flags(0b0000'0010));
@@ -224,7 +224,7 @@ TEST(TXTests, TAXZeroFlag)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x01);
 
     ASSERT_EQ(cpu.flags, make_flags(0b0000'0010));
@@ -246,7 +246,7 @@ TEST(TXTests, TAYZeroFlag)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x01);
 
     ASSERT_EQ(cpu.flags, make_flags(0b0000'0010));
@@ -289,7 +289,7 @@ TEST(TXTests, TYAZeroFlag)
     ASSERT_EQ(cpu.reg.a, 0x00);
     ASSERT_EQ(cpu.reg.x, 0x00);
     ASSERT_EQ(cpu.reg.y, 0x00);
-    ASSERT_EQ(cpu.reg.sp, 0x00);
+    ASSERT_EQ(cpu.reg.sp, 0xff);
     ASSERT_EQ(cpu.reg.pc, 0x01);
 
     ASSERT_EQ(cpu.flags, make_flags(0b0000'0010));
@@ -450,10 +450,4 @@ TEST(TXTests, TYANegativeFlag)
 
         ASSERT_EQ(cpu.flags, make_flags(0b1000'0000));
     }
-}
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
+ Removed the need for main() by linking to gtest::gtest_main.
+ Fixed a bunch of broken tests that expected the SP to be 0x00 initialised.